### PR TITLE
Remove ES+Zookeeper dependencies as of 1.7.0

### DIFF
--- a/docker-compose-cas-es.yml
+++ b/docker-compose-cas-es.yml
@@ -17,24 +17,10 @@ services:
       - temporal-network
     ports:
       - 9200:9200
-  kafka:
-    container_name: temporal-kafka
-    depends_on:
-      - zookeeper
-    environment:
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
-      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-    image: wurstmeister/kafka:2.12-2.1.1
-    networks:
-      - temporal-network
-    ports:
-      - 9092:9092
   temporal:
     container_name: temporal
     depends_on:
       - cassandra
-      - kafka
       - elasticsearch
     environment:
       - CASSANDRA_SEEDS=cassandra
@@ -42,7 +28,6 @@ services:
       - ENABLE_ES=true
       - ES_SEEDS=elasticsearch
       - ES_VERSION=v7
-      - KAFKA_SEEDS=kafka
     image: temporalio/auto-setup:1.7.0
     networks:
       - temporal-network
@@ -73,13 +58,6 @@ services:
       - temporal-network
     ports:
       - 8088:8088
-  zookeeper:
-    container_name: temporal-zookeper
-    image: wurstmeister/zookeeper:3.4.6
-    networks:
-      - temporal-network
-    ports:
-      - 2181:2181
 networks:
   temporal-network:
     driver: bridge

--- a/docker-compose-mysql-es.yml
+++ b/docker-compose-mysql-es.yml
@@ -10,19 +10,6 @@ services:
       - temporal-network
     ports:
       - 9200:9200
-  kafka:
-    container_name: temporal-kafka
-    depends_on:
-      - zookeeper
-    environment:
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
-      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-    image: wurstmeister/kafka:2.12-2.1.1
-    networks:
-      - temporal-network
-    ports:
-      - 9092:9092
   mysql:
     container_name: temporal-mysql
     environment:
@@ -37,7 +24,6 @@ services:
     depends_on:
       - mysql
       - elasticsearch
-      - kafka
     environment:
       - DB=mysql
       - MYSQL_USER=root
@@ -47,7 +33,6 @@ services:
       - ENABLE_ES=true
       - ES_SEEDS=elasticsearch
       - ES_VERSION=v7
-      - KAFKA_SEEDS=kafka
     image: temporalio/auto-setup:1.7.0
     networks:
       - temporal-network
@@ -77,13 +62,6 @@ services:
       - temporal-network
     ports:
       - 8088:8088
-  zookeeper:
-    container_name: temporal-zookeeper
-    image: wurstmeister/zookeeper:3.4.6
-    networks:
-      - temporal-network
-    ports:
-      - 2181:2181
 networks:
   temporal-network:
     driver: bridge

--- a/dynamicconfig/development_es.yaml
+++ b/dynamicconfig/development_es.yaml
@@ -46,7 +46,6 @@ frontend.validSearchAttributes:
       ExecutionStatus: "Int"
       HistoryLength: "Int"
       TaskQueue: "Keyword"
-      KafkaKey: "Keyword"
       Encoding: "Keyword"
       CustomStringField: "String"
       CustomKeywordField: "Keyword"


### PR DESCRIPTION
As of Temporal 1.7.0 Kafka and zookeeper are no longer needed.
This PR removed those dependencies in the docker-compose files.