### PR TITLE
Add configuration for inducing network delay

### DIFF
--- a/docker-compose-network-delay.yml
+++ b/docker-compose-network-delay.yml
@@ -1,0 +1,54 @@
+version: "3.5"
+services:
+  cassandra:
+    container_name: temporal-cassandra
+    image: cassandra:3.11
+    networks:
+      - temporal-network
+    ports:
+      - 9042:9042
+  temporal:
+    container_name: temporal
+    cap_add:
+      - NET_ADMIN
+    depends_on:
+      - cassandra
+    environment:
+      - CASSANDRA_SEEDS=cassandra
+      - DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development.yaml
+    build:
+      context: ./testing
+      dockerfile: Dockerfile
+    networks:
+      - temporal-network
+    ports:
+      - 7233:7233
+    volumes:
+      - ./dynamicconfig:/etc/temporal/config/dynamicconfig
+  temporal-admin-tools:
+    container_name: temporal-admin-tools
+    depends_on:
+      - temporal
+    environment:
+      - TEMPORAL_CLI_ADDRESS=temporal:7233
+    image: temporalio/admin-tools:1.7.0
+    networks:
+      - temporal-network
+    stdin_open: true
+    tty: true
+  temporal-web:
+    container_name: temporal-web
+    depends_on:
+      - temporal
+    environment:
+      - TEMPORAL_GRPC_ENDPOINT=temporal:7233
+      - TEMPORAL_PERMIT_WRITE_API=true
+    image: temporalio/web:1.7.1
+    networks:
+      - temporal-network
+    ports:
+      - 8088:8088
+networks:
+  temporal-network:
+    driver: bridge
+    name: temporal-network

--- a/testing/Dockerfile
+++ b/testing/Dockerfile
@@ -1,0 +1,12 @@
+# Dockerfile with tools that enhance container capabilities for better debugging and testing
+
+FROM temporalio/auto-setup:1.7.0
+
+# iproute2 contains tc, which can be used to inject traffic delay and failures.
+RUN apk add iproute2
+
+# Add any configuration that needs to run when container starts up in this file.
+COPY configure.sh /configure.sh
+
+# Now injecting configuration script before the service startup.
+CMD /configure.sh && /start.sh autosetup

--- a/testing/configure.sh
+++ b/testing/configure.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -x
+
+# Adding artificial delay for all network calls.
+# In order to verify that there is a delay, you can login to the container and run:
+# > tc qdisc show dev eth0
+# To change the delay inside of the running container, run:
+# > tc qdisc del dev eth0 root && tc qdisc add dev eth0 root netem delay 100ms
+#
+# Read more about what's possible with tc here:
+# https://www.badunetworks.com/traffic-shaping-with-tc/
+tc qdisc add dev eth0 root netem delay 50ms


### PR DESCRIPTION
## Description, Motivation and Context

Finding flaky tests that rely on faulty timing assumptions and fast server performance is tricky. Doing it efficiently requires adding artificial delay for server calls. This PR provides ability to start a version of temporal that induces delay for all network calls. Treat this as a starting point, we can iterate on top and add a lot more knobs in the future, for adding packet loss, random lags and database delays. For now this is targeted primarily for finding flaky tests in our SDKs.

## Details
To achieve this goal I've used a tool called `tc`, which is a part of `iproute2` package. I didn't want to add `iproute2` into our main docker image, since it's needed only for testing, that's why I've created a separate `testing/Dockerfile` that builds temporal image with any test packages needed for debugging and resiliancy testing, also this image runs a configuration script, before starting the server, which actually invokes tc tool.


## Running
```
docker-compose -f docker-compose-network-delay.yml up
```