### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - temporal
     environment:
       - TEMPORAL_CLI_ADDRESS=temporal:7233
-    image: temporaliotest/admin-tools:1.8.0
+    image: temporalio/admin-tools:1.8.0
     networks:
       - temporal-network
     stdin_open: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     environment:
       - CASSANDRA_SEEDS=cassandra
       - DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development.yaml
-    image: temporaliotest/auto-setup:1.8.0
+    image: temporalio/auto-setup:1.8.0
     networks:
       - temporal-network
     ports:


### PR DESCRIPTION
image: temporaliotest/auto-setup:1.8.0 doesn't exist

<!--- Reminder to change the title 👆 -->

<!--- For External Contributors -->
<!-- Thanks for opening a PR to our repos! If it is a significant code change,
please make sure there is an  opened issue where we have accepted the idea
before filing this PR. -->

<!--- For All Contributors -->

## What was changed:
<!-- Describe what has changed in this PR -->

## Why?
<!-- Tell your future self why have you made these changes -->

## Closes issue: 
<!--- If it fixes an open issue, please link to the issue here -->

## How has this been tested?
<!--- Please describe how you tested your changes/how we can test them -->


## Any docs updates needed?
<!--- update docs/README in this repo if applicable, or point out where to update docs.temporal.io -->
