### PR TITLE
Remove Custom*Field search attributes from dynamic config

### DIFF
--- a/dynamicconfig/development_es.yaml
+++ b/dynamicconfig/development_es.yaml
@@ -34,26 +34,3 @@ system.advancedVisibilityWritingMode:
 system.enableReadVisibilityFromES:
   - value: true
     constraints: {}
-frontend.validSearchAttributes:
-  - value:
-      NamespaceId: "Keyword"
-      WorkflowId: "Keyword"
-      RunId: "Keyword"
-      WorkflowType: "Keyword"
-      StartTime: "Int"
-      ExecutionTime: "Int"
-      CloseTime: "Int"
-      ExecutionStatus: "Int"
-      HistoryLength: "Int"
-      TaskQueue: "Keyword"
-      Encoding: "Keyword"
-      CustomStringField: "String"
-      CustomKeywordField: "Keyword"
-      CustomIntField: "Int"
-      CustomDoubleField: "Double"
-      CustomBoolField: "Bool"
-      CustomDatetimeField: "Datetime"
-      TemporalChangeVersion: "Keyword"
-      BinaryChecksums: "Keyword"
-      CustomNamespace: "Keyword"
-      Operator: "Keyword"


### PR DESCRIPTION
Search attributes are store in cluster metadata now.