### PR TITLE
Do not expose Elasticsearch and PostgreSQL ports outside of Docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,8 +12,8 @@ services:
     image: elasticsearch:7.10.1
     networks:
       - temporal-network
-    ports:
-      - 9200:9200
+    expose:
+      - 9200
   postgresql:
     container_name: temporal-postgresql
     environment:
@@ -22,8 +22,8 @@ services:
     image: postgres:9.6
     networks:
       - temporal-network
-    ports:
-      - 5432:5432
+    expose:
+      - 5432
   temporal:
     container_name: temporal
     depends_on:


### PR DESCRIPTION
## What was changed
Do not expose Elasticsearch and PostgreSQL ports outside of Docker

# Why?
Elasticsearch service is open (no password), it's better to keep its port NOT exposed outside of the Docker environment. PostgreSQL does have a password, but it's a weak static password, so this port should also not be exposed outside of Docker.

I'm evaluating Temporal.io, and I've got a nasty email from my company's InfoSec department 10 minutes after running `docker-compose up` -- they detected this open Elasticsearch instance on my laptop. That's not a great start.

