### PR TITLE
Elasticsearch should use version 7.16.2 or newer

### DIFF
--- a/docker-compose-cas-es.yml
+++ b/docker-compose-cas-es.yml
@@ -16,7 +16,7 @@ services:
       - cluster.routing.allocation.disk.watermark.flood_stage=128mb
       - discovery.type=single-node
       - ES_JAVA_OPTS=-Xms100m -Xmx100m
-    image: elasticsearch:7.10.1
+    image: elasticsearch:7.16.2
     networks:
       - temporal-network
     ports:

--- a/docker-compose-cockroach-es.yml
+++ b/docker-compose-cockroach-es.yml
@@ -24,7 +24,7 @@ services:
       - cluster.routing.allocation.disk.watermark.flood_stage=128mb
       - discovery.type=single-node
       - ES_JAVA_OPTS=-Xms100m -Xmx100m
-    image: elasticsearch:7.10.1
+    image: elasticsearch:7.16.2
     networks:
       - temporal-network
     ports:

--- a/docker-compose-mysql-es.yml
+++ b/docker-compose-mysql-es.yml
@@ -9,7 +9,7 @@ services:
       - cluster.routing.allocation.disk.watermark.flood_stage=128mb
       - discovery.type=single-node
       - ES_JAVA_OPTS=-Xms100m -Xmx100m
-    image: elasticsearch:7.10.1
+    image: elasticsearch:7.16.2
     networks:
       - temporal-network
     ports:

--- a/docker-compose-ui-experimental.yml
+++ b/docker-compose-ui-experimental.yml
@@ -9,7 +9,7 @@ services:
       - cluster.routing.allocation.disk.watermark.flood_stage=128mb
       - discovery.type=single-node
       - ES_JAVA_OPTS=-Xms100m -Xmx100m
-    image: elasticsearch:7.10.1
+    image: elasticsearch:7.16.2
     networks:
       - temporal-network
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - cluster.routing.allocation.disk.watermark.flood_stage=128mb
       - discovery.type=single-node
       - ES_JAVA_OPTS=-Xms100m -Xmx100m
-    image: elasticsearch:7.10.1
+    image: elasticsearch:7.16.2
     networks:
       - temporal-network
     ports:


### PR DESCRIPTION
Elastic search versions lower than 7.16.2 are subject to the log4j vulnerability as discussed in https://www.elastic.co/blog/log4j2-vulnerability-what-to-know-security-vulnerability-learn-more-elastic-support

## What was changed
Elastic Search dockerfile version

## Why?
Avoid log4j vulnerability

1. Closes (Note to reviewer - the temporalio docker-compose repo doesn't seem to allow us to file issues, only PRs, so I wasn't able to file an issue for this to close)

2. How was this tested:
I'm not using Elastic Search in my deployments so I don't have a test suite to run with this (but fortunately it's a pretty trivial change)

3. Any docs updates needed?
No