### PR TITLE
Add default UI development origin to CORS

### DIFF
--- a/docker-compose-ui-experimental.yml
+++ b/docker-compose-ui-experimental.yml
@@ -63,7 +63,8 @@ services:
       - temporal
     environment:
       - TEMPORAL_ADDRESS=temporal:7233
-    image: temporaliotest/ui:latest
+      - TEMPORAL_CORS_ORIGINS=http://localhost:3000
+    image: temporaliotest/ui:sha-77656f3
     networks:
       - temporal-network
     ports:


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Adds localhost:3000 to allowed CORS origins

## Why?
<!-- Tell your future self why have you made these changes -->

Unblock UI devs at development from ui-server issues

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
