### PR TITLE
Prevent ES deprecation warning spam in logs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - cluster.routing.allocation.disk.watermark.flood_stage=128mb
       - discovery.type=single-node
       - ES_JAVA_OPTS=-Xms100m -Xmx100m
+      - xpack.security.enabled=false
     image: elasticsearch:7.16.2
     networks:
       - temporal-network


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
- Explicitly disable ES security ([for reference](https://github.com/elastic/elasticsearch/issues/78500))

## Why?
<!-- Tell your future self why have you made these changes -->
To prevent a deprecation warning from spamming the logs

```
temporal                | {"level":"error","ts":"2022-02-24T16:45:15.923Z","msg":"Deprecation warning: 299 Elasticsearch-7.16.2-2b937c44140b6559905130a8650c64dbd0879cfb \"Elasticsearch built-in security features are not enabled. Without authentication, your cluster could be accessible to anyone. See https://www.elastic.co/guide/en/elasticsearch/reference/7.16/security-minimal-setup.html to enable security.\"","logging-call-at":"logger.go:48","stacktrace":.....<truncated>
```

## Checklist
<!--- add/delete as needed --->

1. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Ran it locally with this setting, deprecation warning disappeared. 
