### PR TITLE
Bump docker file to use V1.15.1

### DIFF
--- a/docker-compose-cas-es.yml
+++ b/docker-compose-cas-es.yml
@@ -32,7 +32,7 @@ services:
       - ENABLE_ES=true
       - ES_SEEDS=elasticsearch
       - ES_VERSION=v7
-    image: temporalio/auto-setup:1.15.0
+    image: temporalio/auto-setup:1.15.1
     networks:
       - temporal-network
     ports:
@@ -45,7 +45,7 @@ services:
       - temporal
     environment:
       - TEMPORAL_CLI_ADDRESS=temporal:7233
-    image: temporalio/admin-tools:1.15.0
+    image: temporalio/admin-tools:1.15.1
     networks:
       - temporal-network
     stdin_open: true

--- a/docker-compose-cas-es.yml
+++ b/docker-compose-cas-es.yml
@@ -32,7 +32,7 @@ services:
       - ENABLE_ES=true
       - ES_SEEDS=elasticsearch
       - ES_VERSION=v7
-    image: temporalio/auto-setup:1.14.5
+    image: temporalio/auto-setup:1.15.0
     networks:
       - temporal-network
     ports:
@@ -45,7 +45,7 @@ services:
       - temporal
     environment:
       - TEMPORAL_CLI_ADDRESS=temporal:7233
-    image: temporalio/admin-tools:1.14.5
+    image: temporalio/admin-tools:1.15.0
     networks:
       - temporal-network
     stdin_open: true

--- a/docker-compose-cas.yml
+++ b/docker-compose-cas.yml
@@ -14,7 +14,7 @@ services:
     environment:
       - CASSANDRA_SEEDS=cassandra
       - DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development.yaml
-    image: temporalio/auto-setup:1.15.0
+    image: temporalio/auto-setup:1.15.1
     networks:
       - temporal-network
     ports:
@@ -27,7 +27,7 @@ services:
       - temporal
     environment:
       - TEMPORAL_CLI_ADDRESS=temporal:7233
-    image: temporalio/admin-tools:1.15.0
+    image: temporalio/admin-tools:1.15.1
     networks:
       - temporal-network
     stdin_open: true

--- a/docker-compose-cas.yml
+++ b/docker-compose-cas.yml
@@ -14,7 +14,7 @@ services:
     environment:
       - CASSANDRA_SEEDS=cassandra
       - DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development.yaml
-    image: temporalio/auto-setup:1.14.5
+    image: temporalio/auto-setup:1.15.0
     networks:
       - temporal-network
     ports:
@@ -27,7 +27,7 @@ services:
       - temporal
     environment:
       - TEMPORAL_CLI_ADDRESS=temporal:7233
-    image: temporalio/admin-tools:1.14.5
+    image: temporalio/admin-tools:1.15.0
     networks:
       - temporal-network
     stdin_open: true

--- a/docker-compose-cockroach-es.yml
+++ b/docker-compose-cockroach-es.yml
@@ -44,7 +44,7 @@ services:
       - ENABLE_ES=true
       - ES_SEEDS=elasticsearch
       - ES_VERSION=v7
-    image: temporalio/auto-setup:1.14.5
+    image: temporalio/auto-setup:1.15.0
     links:
       - cockroach:postgres
     networks:
@@ -59,7 +59,7 @@ services:
       - temporal
     environment:
       - TEMPORAL_CLI_ADDRESS=temporal:7233
-    image: temporalio/admin-tools:1.14.5
+    image: temporalio/admin-tools:1.15.0
     networks:
       - temporal-network
     stdin_open: true

--- a/docker-compose-cockroach-es.yml
+++ b/docker-compose-cockroach-es.yml
@@ -44,7 +44,7 @@ services:
       - ENABLE_ES=true
       - ES_SEEDS=elasticsearch
       - ES_VERSION=v7
-    image: temporalio/auto-setup:1.15.0
+    image: temporalio/auto-setup:1.15.1
     links:
       - cockroach:postgres
     networks:
@@ -59,7 +59,7 @@ services:
       - temporal
     environment:
       - TEMPORAL_CLI_ADDRESS=temporal:7233
-    image: temporalio/admin-tools:1.15.0
+    image: temporalio/admin-tools:1.15.1
     networks:
       - temporal-network
     stdin_open: true

--- a/docker-compose-cockroach.yml
+++ b/docker-compose-cockroach.yml
@@ -26,7 +26,7 @@ services:
       - POSTGRES_PWD=
       - POSTGRES_SEEDS=postgres
       - DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development.yaml
-    image: temporalio/auto-setup:1.15.0
+    image: temporalio/auto-setup:1.15.1
     links:
       - cockroach:postgres
     networks:
@@ -41,7 +41,7 @@ services:
       - temporal
     environment:
       - TEMPORAL_CLI_ADDRESS=temporal:7233
-    image: temporalio/admin-tools:1.15.0
+    image: temporalio/admin-tools:1.15.1
     networks:
       - temporal-network
     stdin_open: true

--- a/docker-compose-cockroach.yml
+++ b/docker-compose-cockroach.yml
@@ -26,7 +26,7 @@ services:
       - POSTGRES_PWD=
       - POSTGRES_SEEDS=postgres
       - DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development.yaml
-    image: temporalio/auto-setup:1.14.5
+    image: temporalio/auto-setup:1.15.0
     links:
       - cockroach:postgres
     networks:
@@ -41,7 +41,7 @@ services:
       - temporal
     environment:
       - TEMPORAL_CLI_ADDRESS=temporal:7233
-    image: temporalio/admin-tools:1.14.5
+    image: temporalio/admin-tools:1.15.0
     networks:
       - temporal-network
     stdin_open: true

--- a/docker-compose-mysql-es.yml
+++ b/docker-compose-mysql-es.yml
@@ -37,7 +37,7 @@ services:
       - ENABLE_ES=true
       - ES_SEEDS=elasticsearch
       - ES_VERSION=v7
-    image: temporalio/auto-setup:1.14.5
+    image: temporalio/auto-setup:1.15.0
     networks:
       - temporal-network
     ports:
@@ -50,7 +50,7 @@ services:
       - temporal
     environment:
       - TEMPORAL_CLI_ADDRESS=temporal:7233
-    image: temporalio/admin-tools:1.14.5
+    image: temporalio/admin-tools:1.15.0
     networks:
       - temporal-network
     stdin_open: true

--- a/docker-compose-mysql-es.yml
+++ b/docker-compose-mysql-es.yml
@@ -37,7 +37,7 @@ services:
       - ENABLE_ES=true
       - ES_SEEDS=elasticsearch
       - ES_VERSION=v7
-    image: temporalio/auto-setup:1.15.0
+    image: temporalio/auto-setup:1.15.1
     networks:
       - temporal-network
     ports:
@@ -50,7 +50,7 @@ services:
       - temporal
     environment:
       - TEMPORAL_CLI_ADDRESS=temporal:7233
-    image: temporalio/admin-tools:1.15.0
+    image: temporalio/admin-tools:1.15.1
     networks:
       - temporal-network
     stdin_open: true

--- a/docker-compose-mysql.yml
+++ b/docker-compose-mysql.yml
@@ -20,7 +20,7 @@ services:
       - MYSQL_PWD=root
       - MYSQL_SEEDS=mysql
       - DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development.yaml
-    image: temporalio/auto-setup:1.14.5
+    image: temporalio/auto-setup:1.15.0
     networks:
       - temporal-network
     ports:
@@ -33,7 +33,7 @@ services:
       - temporal
     environment:
       - TEMPORAL_CLI_ADDRESS=temporal:7233
-    image: temporalio/admin-tools:1.14.5
+    image: temporalio/admin-tools:1.15.0
     networks:
       - temporal-network
     stdin_open: true

--- a/docker-compose-mysql.yml
+++ b/docker-compose-mysql.yml
@@ -20,7 +20,7 @@ services:
       - MYSQL_PWD=root
       - MYSQL_SEEDS=mysql
       - DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development.yaml
-    image: temporalio/auto-setup:1.15.0
+    image: temporalio/auto-setup:1.15.1
     networks:
       - temporal-network
     ports:
@@ -33,7 +33,7 @@ services:
       - temporal
     environment:
       - TEMPORAL_CLI_ADDRESS=temporal:7233
-    image: temporalio/admin-tools:1.15.0
+    image: temporalio/admin-tools:1.15.1
     networks:
       - temporal-network
     stdin_open: true

--- a/docker-compose-postgres.yml
+++ b/docker-compose-postgres.yml
@@ -21,7 +21,7 @@ services:
       - POSTGRES_PWD=temporal
       - POSTGRES_SEEDS=postgresql
       - DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development.yaml
-    image: temporalio/auto-setup:1.15.0
+    image: temporalio/auto-setup:1.15.1
     networks:
       - temporal-network
     ports:
@@ -34,7 +34,7 @@ services:
       - temporal
     environment:
       - TEMPORAL_CLI_ADDRESS=temporal:7233
-    image: temporalio/admin-tools:1.15.0
+    image: temporalio/admin-tools:1.15.1
     networks:
       - temporal-network
     stdin_open: true

--- a/docker-compose-postgres.yml
+++ b/docker-compose-postgres.yml
@@ -21,7 +21,7 @@ services:
       - POSTGRES_PWD=temporal
       - POSTGRES_SEEDS=postgresql
       - DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development.yaml
-    image: temporalio/auto-setup:1.14.5
+    image: temporalio/auto-setup:1.15.0
     networks:
       - temporal-network
     ports:
@@ -34,7 +34,7 @@ services:
       - temporal
     environment:
       - TEMPORAL_CLI_ADDRESS=temporal:7233
-    image: temporalio/admin-tools:1.14.5
+    image: temporalio/admin-tools:1.15.0
     networks:
       - temporal-network
     stdin_open: true

--- a/docker-compose-ui-experimental.yml
+++ b/docker-compose-ui-experimental.yml
@@ -39,7 +39,7 @@ services:
       - ENABLE_ES=true
       - ES_SEEDS=elasticsearch
       - ES_VERSION=v7
-    image: temporalio/auto-setup:1.15.0
+    image: temporalio/auto-setup:1.15.1
     networks:
       - temporal-network
     ports:
@@ -52,7 +52,7 @@ services:
       - temporal
     environment:
       - TEMPORAL_CLI_ADDRESS=temporal:7233
-    image: temporalio/admin-tools:1.15.0
+    image: temporalio/admin-tools:1.15.1
     networks:
       - temporal-network
     stdin_open: true

--- a/docker-compose-ui-experimental.yml
+++ b/docker-compose-ui-experimental.yml
@@ -39,7 +39,7 @@ services:
       - ENABLE_ES=true
       - ES_SEEDS=elasticsearch
       - ES_VERSION=v7
-    image: temporalio/auto-setup:1.14.5
+    image: temporalio/auto-setup:1.15.0
     networks:
       - temporal-network
     ports:
@@ -52,7 +52,7 @@ services:
       - temporal
     environment:
       - TEMPORAL_CLI_ADDRESS=temporal:7233
-    image: temporalio/admin-tools:1.14.5
+    image: temporalio/admin-tools:1.15.0
     networks:
       - temporal-network
     stdin_open: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       - ENABLE_ES=true
       - ES_SEEDS=elasticsearch
       - ES_VERSION=v7
-    image: temporalio/auto-setup:1.15.0
+    image: temporalio/auto-setup:1.15.1
     networks:
       - temporal-network
     ports:
@@ -52,7 +52,7 @@ services:
       - temporal
     environment:
       - TEMPORAL_CLI_ADDRESS=temporal:7233
-    image: temporalio/admin-tools:1.15.0
+    image: temporalio/admin-tools:1.15.1
     networks:
       - temporal-network
     stdin_open: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       - ENABLE_ES=true
       - ES_SEEDS=elasticsearch
       - ES_VERSION=v7
-    image: temporalio/auto-setup:1.14.5
+    image: temporalio/auto-setup:1.15.0
     networks:
       - temporal-network
     ports:
@@ -52,7 +52,7 @@ services:
       - temporal
     environment:
       - TEMPORAL_CLI_ADDRESS=temporal:7233
-    image: temporalio/admin-tools:1.14.5
+    image: temporalio/admin-tools:1.15.0
     networks:
       - temporal-network
     stdin_open: true


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Bump docker file to use V1.15.1

## Why?
Bump docker file to use V1.15.1 for new server v1.15.1 patch

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
