### PR TITLE
Increment ES memory limit to 300Mb

### DIFF
--- a/docker-compose-cas-es.yml
+++ b/docker-compose-cas-es.yml
@@ -15,7 +15,7 @@ services:
       - cluster.routing.allocation.disk.watermark.high=256mb
       - cluster.routing.allocation.disk.watermark.flood_stage=128mb
       - discovery.type=single-node
-      - ES_JAVA_OPTS=-Xms100m -Xmx100m
+      - ES_JAVA_OPTS=-Xms256m -Xmx256m
       - xpack.security.enabled=false
     image: elasticsearch:${ELASTICSEARCH_VERSION}
     networks:

--- a/docker-compose-cockroach-es.yml
+++ b/docker-compose-cockroach-es.yml
@@ -23,7 +23,7 @@ services:
       - cluster.routing.allocation.disk.watermark.high=256mb
       - cluster.routing.allocation.disk.watermark.flood_stage=128mb
       - discovery.type=single-node
-      - ES_JAVA_OPTS=-Xms100m -Xmx100m
+      - ES_JAVA_OPTS=-Xms256m -Xmx256m
       - xpack.security.enabled=false
     image: elasticsearch:${ELASTICSEARCH_VERSION}
     networks:

--- a/docker-compose-mysql-es.yml
+++ b/docker-compose-mysql-es.yml
@@ -8,7 +8,7 @@ services:
       - cluster.routing.allocation.disk.watermark.high=256mb
       - cluster.routing.allocation.disk.watermark.flood_stage=128mb
       - discovery.type=single-node
-      - ES_JAVA_OPTS=-Xms100m -Xmx100m
+      - ES_JAVA_OPTS=-Xms256m -Xmx256m
       - xpack.security.enabled=false
     image: elasticsearch:${ELASTICSEARCH_VERSION}
     networks:

--- a/docker-compose-tls.yml
+++ b/docker-compose-tls.yml
@@ -8,7 +8,7 @@ services:
       - cluster.routing.allocation.disk.watermark.high=256mb
       - cluster.routing.allocation.disk.watermark.flood_stage=128mb
       - discovery.type=single-node
-      - ES_JAVA_OPTS=-Xms100m -Xmx100m
+      - ES_JAVA_OPTS=-Xms256m -Xmx256m
       - ELASTIC_PASSWORD=elastic
       - xpack.security.enabled=true
       - xpack.security.http.ssl.enabled=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - cluster.routing.allocation.disk.watermark.high=256mb
       - cluster.routing.allocation.disk.watermark.flood_stage=128mb
       - discovery.type=single-node
-      - ES_JAVA_OPTS=-Xms100m -Xmx100m
+      - ES_JAVA_OPTS=-Xms256m -Xmx256m
       - xpack.security.enabled=false
     image: elasticsearch:${ELASTICSEARCH_VERSION}
     networks:


### PR DESCRIPTION
I had this increase in my local branch forever to deal with local OOO I was observing with some amount of data during non-fresh starts. 
And I just witnessed a user getting ES JVM OutOfMemory on a completely fresh start of docker-compose on MacOS.
