### PR TITLE
Update readme - fix v2 web ui section

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,11 +72,16 @@ Here is a list of available files and the dependencies they use.
 
 ### Using the new, experimental web interface
 
+`docker-compose.yml ` includes both the Temporal Web UI v1, and the new Temporal Web UI v2.
+
+If you run command:
+
 ```bash
-docker-compose -f docker-compose-ui-experimental.yml up
+docker-compose up
 ```
 
-The web interface is located at `http://localhost:8080` by default.
+You access the new Temporal Web UI v2 at `http://localhost:8080`.
+Note that you can also access the Temporal Web UI v1 at `http://localhost:8088`.
 
 ### Enabling metrics (with Grafana and Prometheus)
 


### PR DESCRIPTION
Signed-off-by: Tihomir Surdilovic <tihomir@temporal.io>

Updates the web ui v2 section in readme. The mentioned docker compose yml no longer exists, and the the default one
includes both v1 and v2. 