### PR TITLE
Enable docker build kit

### DIFF
--- a/tls/run-tls.sh
+++ b/tls/run-tls.sh
@@ -2,7 +2,7 @@
 set -xe
 
 # Build container image for generating cert material
-docker build -t temporal_tls:test -f ${PWD}/tls/Dockerfile.tls .
+DOCKER_BUILDKIT=1 docker build -t temporal_tls:test -f ${PWD}/tls/Dockerfile.tls .
 mkdir -p .pki
 
 # Run container to name volume and copy out CA certificate


### PR DESCRIPTION
Since a feature `RUN <<EOF` from the docker build kit is being used, it would be a good idea to enable it while running docker build, as the build may not work in some systems.

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Added `DOCKER_BUILDKIT=1` in the run-tls script
<!-- Describe what has changed in this PR -->

## Why?
The `RUN <<EOF` feature was not working in some systems. For some reason build kit had to be manually turned on for it to work in those cases
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
