### PR TITLE
fix/selinux: Fix startup on a host with active selinux

### DIFF
--- a/docker-compose-cass-es.yml
+++ b/docker-compose-cass-es.yml
@@ -39,7 +39,7 @@ services:
     ports:
       - 7233:7233
     volumes:
-      - ./dynamicconfig:/etc/temporal/config/dynamicconfig
+      - ./dynamicconfig:/etc/temporal/config/dynamicconfig:z
   temporal-admin-tools:
     container_name: temporal-admin-tools
     depends_on:

--- a/docker-compose-cass.yml
+++ b/docker-compose-cass.yml
@@ -20,7 +20,7 @@ services:
     ports:
       - 7233:7233
     volumes:
-      - ./dynamicconfig:/etc/temporal/config/dynamicconfig
+      - ./dynamicconfig:/etc/temporal/config/dynamicconfig:z
   temporal-admin-tools:
     container_name: temporal-admin-tools
     depends_on:

--- a/docker-compose-cockroach-es.yml
+++ b/docker-compose-cockroach-es.yml
@@ -53,7 +53,7 @@ services:
     ports:
       - 7233:7233
     volumes:
-      - ./dynamicconfig:/etc/temporal/config/dynamicconfig
+      - ./dynamicconfig:/etc/temporal/config/dynamicconfig:z
   temporal-admin-tools:
     container_name: temporal-admin-tools
     depends_on:

--- a/docker-compose-cockroach.yml
+++ b/docker-compose-cockroach.yml
@@ -34,7 +34,7 @@ services:
     ports:
       - 7233:7233
     volumes:
-      - ./dynamicconfig:/etc/temporal/config/dynamicconfig
+      - ./dynamicconfig:/etc/temporal/config/dynamicconfig:z
   temporal-admin-tools:
     container_name: temporal-admin-tools
     depends_on:

--- a/docker-compose-mysql-es.yml
+++ b/docker-compose-mysql-es.yml
@@ -44,7 +44,7 @@ services:
     ports:
       - 7233:7233
     volumes:
-      - ./dynamicconfig:/etc/temporal/config/dynamicconfig
+      - ./dynamicconfig:/etc/temporal/config/dynamicconfig:z
   temporal-admin-tools:
     container_name: temporal-admin-tools
     depends_on:

--- a/docker-compose-mysql.yml
+++ b/docker-compose-mysql.yml
@@ -26,7 +26,7 @@ services:
     ports:
       - 7233:7233
     volumes:
-      - ./dynamicconfig:/etc/temporal/config/dynamicconfig
+      - ./dynamicconfig:/etc/temporal/config/dynamicconfig:z
   temporal-admin-tools:
     container_name: temporal-admin-tools
     depends_on:

--- a/docker-compose-postgres.yml
+++ b/docker-compose-postgres.yml
@@ -27,7 +27,7 @@ services:
     ports:
       - 7233:7233
     volumes:
-      - ./dynamicconfig:/etc/temporal/config/dynamicconfig
+      - ./dynamicconfig:/etc/temporal/config/dynamicconfig:z
   temporal-admin-tools:
     container_name: temporal-admin-tools
     depends_on:

--- a/docker-compose-tls.yml
+++ b/docker-compose-tls.yml
@@ -79,7 +79,7 @@ services:
     ports:
       - 7233:7233
     volumes:
-      - ./dynamicconfig:/etc/temporal/config/dynamicconfig
+      - ./dynamicconfig:/etc/temporal/config/dynamicconfig:z
     restart: on-failure
   temporal-admin-tools:
     container_name: temporal-admin-tools

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,7 @@ services:
     ports:
       - 7233:7233
     volumes:
-      - ./dynamicconfig:/etc/temporal/config/dynamicconfig
+      - ./dynamicconfig:/etc/temporal/config/dynamicconfig:z
   temporal-admin-tools:
     container_name: temporal-admin-tools
     depends_on:


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Added `z` option for volumes (https://docs.docker.com/storage/bind-mounts/#configure-the-selinux-label).

## Why?
To fix the startup on a host with selinux active.

## Checklist
<!--- add/delete as needed --->

1. How was this tested:
    The `docker-compose up` command was executed with selinux on and off.

2. Any docs updates needed?
    Nope
