### PR TITLE
Start temporal server allowing no auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ cd  docker-compose
 docker-compose up
 ```
 
+> ⚠️ Default configutation starts Temporal Server without any authorizer.
+> Check the [documentation](https://docs.temporal.io/concepts/what-is-an-authorizer-plugin/)
+> for more info about authorizers.
+
 > ⚠️ If you are on an M1 Mac, note that Temporal v1.12 to v1.14 had fatal issues with ARM builds. v1.14.2 onwards should be fine for M1 Macs.
 
 After the Server has started, you can open the Temporal Web UI in your browser: [http://localhost:8088](http://localhost:8088).

--- a/docker-compose-cass-es.yml
+++ b/docker-compose-cass-es.yml
@@ -28,6 +28,7 @@ services:
       - cassandra
       - elasticsearch
     environment:
+      - TEMPORAL_ALLOW_NO_AUTH=true
       - CASSANDRA_SEEDS=cassandra
       - DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development-cass.yaml
       - ENABLE_ES=true

--- a/docker-compose-cass.yml
+++ b/docker-compose-cass.yml
@@ -12,6 +12,7 @@ services:
     depends_on:
       - cassandra
     environment:
+      - TEMPORAL_ALLOW_NO_AUTH=true
       - CASSANDRA_SEEDS=cassandra
       - DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development-cass.yaml
     image: temporalio/auto-setup:${TEMPORAL_VERSION}

--- a/docker-compose-cockroach-es.yml
+++ b/docker-compose-cockroach-es.yml
@@ -36,6 +36,7 @@ services:
       - cockroach
       - elasticsearch
     environment:
+      - TEMPORAL_ALLOW_NO_AUTH=true
       - DB=postgresql
       - DB_PORT=26257
       - POSTGRES_USER=root

--- a/docker-compose-cockroach.yml
+++ b/docker-compose-cockroach.yml
@@ -20,6 +20,7 @@ services:
     depends_on:
       - cockroach
     environment:
+      - TEMPORAL_ALLOW_NO_AUTH=true
       - DB=postgresql
       - DB_PORT=26257
       - POSTGRES_USER=root

--- a/docker-compose-mysql-es.yml
+++ b/docker-compose-mysql-es.yml
@@ -30,6 +30,7 @@ services:
       - mysql
       - elasticsearch
     environment:
+      - TEMPORAL_ALLOW_NO_AUTH=true
       - DB=mysql
       - MYSQL_USER=root
       - MYSQL_PWD=root

--- a/docker-compose-mysql.yml
+++ b/docker-compose-mysql.yml
@@ -14,6 +14,7 @@ services:
     depends_on:
       - mysql
     environment:
+      - TEMPORAL_ALLOW_NO_AUTH=true
       - DB=mysql
       - DB_PORT=3306
       - MYSQL_USER=root

--- a/docker-compose-postgres.yml
+++ b/docker-compose-postgres.yml
@@ -15,6 +15,7 @@ services:
     depends_on:
       - postgresql
     environment:
+      - TEMPORAL_ALLOW_NO_AUTH=true
       - DB=postgresql
       - DB_PORT=5432
       - POSTGRES_USER=temporal

--- a/docker-compose-tls.yml
+++ b/docker-compose-tls.yml
@@ -61,6 +61,7 @@ services:
       - postgresql
       - elasticsearch
     environment:
+      - TEMPORAL_ALLOW_NO_AUTH=true
       - DB=postgresql
       - DB_PORT=5432
       - POSTGRES_USER=temporal

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       - postgresql
       - elasticsearch
     environment:
+      - TEMPORAL_ALLOW_NO_AUTH=true
       - DB=postgresql
       - DB_PORT=5432
       - POSTGRES_USER=temporal


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Adding a flag to temporal server to allow starting it with no authorizer.

## Why?
<!-- Tell your future self why have you made these changes -->
Temporal server changed behavior to require explicit indication that no authorizer is being used.
