### PR TITLE
Update Dockerfile.admin-tools-tls

### DIFF
--- a/tls/Dockerfile.admin-tools-tls
+++ b/tls/Dockerfile.admin-tools-tls
@@ -1,6 +1,8 @@
 ARG BASEIMAGE
 FROM temporalio/${BASEIMAGE}
 
+USER root
+
 COPY ./.pki/ca.pem /usr/local/share/ca-certificates/ca.crt
 
 RUN update-ca-certificates


### PR DESCRIPTION
Solving permission error while running update-ca-certificates (see https://community.temporal.io/t/docker-compose-tls-installation-failed/7895)

## What was changed
A single line was added to solve the following error while running `bash ./tls/run-tls.sh` following the `tls` setup README.md:
```
 => ERROR [temporal-admin-tools 3/3] RUN update-ca-certificates                                                                                                                                                  0.2s
------
 > [temporal-admin-tools 3/3] RUN update-ca-certificates:
#0 0.203 Failed to open temporary file /etc/ssl/certs/bundleXXXXXX for ca bundle
------
failed to solve: process "/bin/bash -c update-ca-certificates" did not complete successfully: exit code: 1
```

## Why?
By adding the line `USER root`, docker is able to successfully execute the `update-ca-certificates` command located in the changed file. 

## Checklist
<!--- add/delete as needed --->

2. How was this tested:
Built and executed on Ubuntu 22.04 according to the README.md. 

3. Any docs updates needed?
Not to my knowledge.
