### PR TITLE
add :Z mount flag for temporal container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,7 @@ services:
     labels:
       kompose.volume.type: configMap
     volumes:
-      - ./dynamicconfig:/etc/temporal/config/dynamicconfig
+      - ./dynamicconfig:/etc/temporal/config/dynamicconfig:Z
   temporal-admin-tools:
     container_name: temporal-admin-tools
     depends_on:


### PR DESCRIPTION
## The Issue

When running under `podman-compose` and rootless podman on a Linux system with selinux enabled, the `temporal` container does not start because the `dynamicconfig` mount fails.  This leads to a "500" error page when accessing http://localhost:8080

## Why?

When selinux is enabled on the host system, bind mounts need to be relabeled or the mount fails and the container with the mount will not start.

The `Z` flag modifies the selinux label so the podman process can access the bind mounted directory. The option has no effect when running without selinux enabled.  reference: https://docs.docker.com/storage/bind-mounts/#configure-the-selinux-label

see also: https://docs.podman.io/en/latest/markdown/podman-run.1.html#volume-v-source-volume-host-dir-container-dir-options

There are other ways to enable the composed containers to run on an selinux-enabled host system with rootless podman; if you don't want to take on a change like this, it might help others to indicate the system setup options that will enable this application in the documentation.

Change was tested with docker 24.0.5 on Unbuntu 23.04 with selinux disabled, and Fedora 38 with podman 4.7.0 and podman-compose 1.0.6, and selinux enabled.  Both led to a usable page at http://localhost:8080, but I can't vouch for the resulting system working in *all* aspects.

(sorry, unable to create issues so this is how I've manged to do it)
