### PR TITLE
Set TEMPORAL_ADDRESS/TEMPORAL_CLI_ADDRESS on temporal container.

### DIFF
--- a/docker-compose-cass-es.yml
+++ b/docker-compose-cass-es.yml
@@ -37,6 +37,8 @@ services:
       - ENABLE_ES=true
       - ES_SEEDS=elasticsearch
       - ES_VERSION=v7
+      - TEMPORAL_ADDRESS=temporal:7233
+      - TEMPORAL_CLI_ADDRESS=temporal:7233
     image: temporalio/auto-setup:${TEMPORAL_VERSION}
     networks:
       - temporal-network

--- a/docker-compose-mysql-es.yml
+++ b/docker-compose-mysql-es.yml
@@ -42,6 +42,8 @@ services:
       - ENABLE_ES=true
       - ES_SEEDS=elasticsearch
       - ES_VERSION=v7
+      - TEMPORAL_ADDRESS=temporal:7233
+      - TEMPORAL_CLI_ADDRESS=temporal:7233
     image: temporalio/auto-setup:${TEMPORAL_VERSION}
     networks:
       - temporal-network

--- a/docker-compose-mysql.yml
+++ b/docker-compose-mysql.yml
@@ -22,6 +22,8 @@ services:
       - MYSQL_PWD=root
       - MYSQL_SEEDS=mysql
       - DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development-sql.yaml
+      - TEMPORAL_ADDRESS=temporal:7233
+      - TEMPORAL_CLI_ADDRESS=temporal:7233
     image: temporalio/auto-setup:${TEMPORAL_VERSION}
     networks:
       - temporal-network

--- a/docker-compose-postgres-opensearch.yml
+++ b/docker-compose-postgres-opensearch.yml
@@ -51,6 +51,8 @@ services:
       - ENABLE_ES=true
       - ES_SEEDS=opensearch
       - ES_VERSION=v7
+      - TEMPORAL_ADDRESS=temporal:7233
+      - TEMPORAL_CLI_ADDRESS=temporal:7233
     image: temporalio/auto-setup:${TEMPORAL_VERSION}
     networks:
       - temporal-network

--- a/docker-compose-postgres.yml
+++ b/docker-compose-postgres.yml
@@ -23,6 +23,8 @@ services:
       - POSTGRES_PWD=temporal
       - POSTGRES_SEEDS=postgresql
       - DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development-sql.yaml
+      - TEMPORAL_ADDRESS=temporal:7233
+      - TEMPORAL_CLI_ADDRESS=temporal:7233
     image: temporalio/auto-setup:${TEMPORAL_VERSION}
     networks:
       - temporal-network

--- a/docker-compose-tls.yml
+++ b/docker-compose-tls.yml
@@ -76,6 +76,8 @@ services:
       - ES_SCHEME=https
       - ES_USER=elastic
       - ES_PWD=elastic
+      - TEMPORAL_ADDRESS=temporal:7233
+      - TEMPORAL_CLI_ADDRESS=temporal:7233
     networks:
       - temporal-network
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,8 @@ services:
       - ENABLE_ES=true
       - ES_SEEDS=elasticsearch
       - ES_VERSION=v7
+      - TEMPORAL_ADDRESS=temporal:7233
+      - TEMPORAL_CLI_ADDRESS=temporal:7233
     image: temporalio/auto-setup:${TEMPORAL_VERSION}
     networks:
       - temporal-network


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Set TEMPORAL_ADDRESS/TEMPORAL_CLI_ADDRESS on temporal container.

## Why?
This avoids some auto-detection log messages and allows the temporal cli to connect to the server in the temporal container, not just temporal-admin-tools.

<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/docker-compose/issues/225

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
