### PR TITLE
docs: update readme to remove cassandra-only setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ Here is a list of available files and the dependencies they use.
 | docker-compose.yml                     | PostgreSQL and Elasticsearch (default)                        |
 | docker-compose-tls.yml                 | PostgreSQL and Elasticsearch with TLS                         |
 | docker-compose-postgres.yml            | PostgreSQL                                                    |
-| docker-compose-cass.yml                | Cassandra                                                     |
 | docker-compose-cass-es.yml             | Cassandra and Elasticsearch                                   |
 | docker-compose-mysql.yml               | MySQL                                                         |
 | docker-compose-mysql-es.yml            | MySQL and Elasticsearch                                       |


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Cassandra-only setup has been removed since v1.21 so updated docs to remove reference to Cassandra-only setup

## Why?
<!-- Tell your future self why have you made these changes -->
Confusing as to why the file doesn't exist

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
