### PR TITLE
Update CODEOWNERS to reflect team name change

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @temporalio/devex
+* @temporalio/selfhosted


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
I changed the team name in the `CODEOWNERS` file from `devex` to `selfhosted`

## Why?
<!-- Tell your future self why have you made these changes -->
GitHub reports that the current `CODEOWNERS` file is invalid:

![image](https://github.com/user-attachments/assets/b6c2b1e7-5a2c-4ad9-8ba3-998fe3446582)

This is because the `DevEx` team within the temporalio org on GitHub was renamed to `selfhosted` some months ago. My change updates the file to use the correct name; that is, the one for which there's actually a team defined.