### PR TITLE
Fix TLS setup

### DIFF
--- a/docker-compose-tls.yml
+++ b/docker-compose-tls.yml
@@ -96,8 +96,8 @@ services:
       context: .
       dockerfile: tls/Dockerfile.admin-tools-tls
       args:
-        - BASEIMAGE=admin-tools:${TEMPORAL_VERSION}
-    image: temporalio/admin-tools-tls:${TEMPORAL_VERSION}
+        - BASEIMAGE=admin-tools:${TEMPORAL_ADMINTOOLS_VERSION}
+    image: temporalio/admin-tools-tls:${TEMPORAL_ADMINTOOLS_VERSION}
     networks:
       - temporal-network
     stdin_open: true

--- a/tls/Dockerfile.admin-tools-tls
+++ b/tls/Dockerfile.admin-tools-tls
@@ -1,6 +1,9 @@
 ARG BASEIMAGE
 FROM temporalio/${BASEIMAGE}
 
+USER root
 COPY ./.pki/ca.pem /usr/local/share/ca-certificates/ca.crt
 
 RUN update-ca-certificates
+
+USER temporal


### PR DESCRIPTION
## What was changed
Fixes TLS setup:
1. It was using non existing version of admin-tools:1.28.0: `target temporal-admin-tools: failed to solve: temporalio/admin-tools:1.28.0: failed to resolve source metadata for docker.io/temporalio/admin-tools:1.28.0: docker.io/temporalio/admin-tools:1.28.0: not found`. Should have used TEMPORAL_ADMINTOOLS_VERSION env variable instead of TEMPORAL_VERSION.
2. It was running update-ca-certificates without root

## Why?
Fixes broken `tls/run-tls.sh`

## Checklist
1. How was this tested:
`tls/run-tls.sh` succeeds on Mac

2. Any docs updates needed?
No