### PR TITLE
Update CODEOWNERS to include server team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @temporalio/selfhosted
+* @temporalio/server


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
I replaced the `selfhosted` team with the `server` team, following Roey's confirmation of ownership. 


## Why?
<!-- Tell your future self why have you made these changes -->
Rob Holland and I agreed that this shouldn't be owned by DevRel, of which the SelfHosted team is a subset. Although members of that team have historically contributed to it, I have since learned that it's owned by the server team. This change reflects that. 
